### PR TITLE
add require statement for lodash

### DIFF
--- a/Utils/computeProps.js
+++ b/Utils/computeProps.js
@@ -2,6 +2,8 @@ var React = require('react');
 
 var ReactNativePropRegistry = require('react/lib/ReactNativePropRegistry');
 
+var _ = require('lodash');
+
 module.exports = function(incomingProps, defaultProps) {
 
 


### PR DESCRIPTION
Emulator would not compile this library because it was trying to use an undeclared variable "_".

I just added a require statement to load the lodash library, it is being referenced/used but not loaded.