### PR TITLE
Allow rows to have fixed height

### DIFF
--- a/Components/Row.js
+++ b/Components/Row.js
@@ -13,7 +13,7 @@ export default class RowNB extends Component {
 
         var type = {
         	flexDirection: 'row',
-        	flex: (this.props.size) ? this.props.size : 1,
+        	flex: (this.props.size) ? this.props.size : (this.props.style && this.props.style.height) ? 0 : 1,
         }
 
         var defaultProps = {


### PR DESCRIPTION
A fix for this [issue](https://github.com/GeekyAnts/react-native-easy-grid/issues/9)