### PR TITLE
Fixed import of ReactNativePropRegistry to be not path specific.

### DIFF
--- a/Utils/computeProps.js
+++ b/Utils/computeProps.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var ReactNativePropRegistry = require('react/lib/ReactNativePropRegistry');
+var ReactNativePropRegistry = require('react-native');
 var _ = require('lodash');
 
 module.exports = function(incomingProps, defaultProps) {


### PR DESCRIPTION
This addresses issue #18 by fixing how ReactNativePropRegistry is imported/required.