### PR TITLE
Check for null while checking for rows in grid children

### DIFF
--- a/Components/Grid.js
+++ b/Components/Grid.js
@@ -28,7 +28,7 @@ export default class GridNB extends Component {
     ifRow() {
         var row = false;
         React.Children.forEach(this.props.children, function (child) {
-            if(child.type == Row)
+            if(child && child.type == Row)
                 row = true;
         })
         return row;


### PR DESCRIPTION
The following fails because of no null check in  [this](https://github.com/GeekyAnts/react-native-easy-grid/blob/master/Components/Grid.js#L31) line.

```
const SomeComponent = () => (
  <Grid>
    <Col>Col1</Col>
    { someCondition && <Col>Col2</Col>} // this renders a falsy node here if condition not met
  <Grid>
)

```