### PR TITLE
Fix lodash import for babel-plugin-lodash.

### DIFF
--- a/Components/Col.js
+++ b/Components/Col.js
@@ -3,7 +3,6 @@
 import React, {Component} from 'react';
 import {View, TouchableOpacity} from 'react-native';
 import computeProps from '../Utils/computeProps';
-import _ from 'lodash';
 
 
 export default class ColumnNB extends Component {

--- a/Components/Grid.js
+++ b/Components/Grid.js
@@ -3,7 +3,6 @@
 import React, {Component} from 'react';
 import {View, TouchableOpacity} from 'react-native';
 import computeProps from '../Utils/computeProps';
-import _ from 'lodash';
 import Col from './Col';
 import Row from './Row';
 

--- a/Components/Row.js
+++ b/Components/Row.js
@@ -4,7 +4,6 @@ import React, {Component} from 'react';
 import {View, TouchableOpacity} from 'react-native';
 
 import computeProps from '../Utils/computeProps';
-import _ from 'lodash';
 
 
 export default class RowNB extends Component {

--- a/Utils/computeProps.js
+++ b/Utils/computeProps.js
@@ -1,7 +1,7 @@
 var React = require("react");
 import ReactNativePropRegistry
   from "react-native/Libraries/Renderer/shims/ReactNativePropRegistry";
-var _ = require("lodash");
+import _ from 'lodash';
 
 module.exports = function(incomingProps, defaultProps) {
   // External props has a higher precedence

--- a/index.js
+++ b/index.js
@@ -6,8 +6,4 @@ import Grid from './Components/Grid';
 import Col from './Components/Col';
 
 
-module.exports = {
-	Row: Row,
-	Col: Col,
-	Grid: Grid
-};
+export { Row, Col, Grid };


### PR DESCRIPTION
The three components imported lodash unnecessarily, and `Utils/computeProps.js`
used `require` instead of `import`.