### PR TITLE
Use ES6 export for computeProps.

### DIFF
--- a/Utils/computeProps.js
+++ b/Utils/computeProps.js
@@ -1,9 +1,9 @@
-var React = require("react");
+import React from "react";
 import ReactNativePropRegistry
   from "react-native/Libraries/Renderer/shims/ReactNativePropRegistry";
 var _ = require("lodash");
 
-module.exports = function(incomingProps, defaultProps) {
+function computeProps(incomingProps, defaultProps) {
   // External props has a higher precedence
   var computedProps = {};
 
@@ -47,3 +47,5 @@ module.exports = function(incomingProps, defaultProps) {
 
   return computedProps;
 };
+
+export default computeProps;


### PR DESCRIPTION
Mixing `import` statements with `module.exports` causes issues when using Webpack/Rollup with ES6 modules and tree shaking. The default export isn't found in this situation. This fixes that.