### PR TITLE
Normalizing style prop before reading

### DIFF
--- a/Components/Col.js
+++ b/Components/Col.js
@@ -1,16 +1,18 @@
 'use strict';
 
 import React, {Component} from 'react';
-import {View, TouchableOpacity} from 'react-native';
+import {View, TouchableOpacity, StyleSheet} from 'react-native';
 import computeProps from '../Utils/computeProps';
 
 
 export default class ColumnNB extends Component {
     prepareRootProps() {
 
+        var flattenedStyle = StyleSheet.flatten(this.props.style)
+
         var type = {
         	flexDirection: 'column',
-        	flex: (this.props.size) ? this.props.size : (this.props.style && this.props.style.width) ? 0 : 1,
+        	flex: (this.props.size) ? this.props.size : (flattenedStyle && flattenedStyle.width) ? 0 : 1,
         }
 
         var defaultProps = {
@@ -20,7 +22,7 @@ export default class ColumnNB extends Component {
 
     }
 
-    setNativeProps(nativeProps) {
+
       this._root.setNativeProps(nativeProps);
     }
 

--- a/Components/Col.js
+++ b/Components/Col.js
@@ -22,7 +22,7 @@ export default class ColumnNB extends Component {
 
     }
 
-
+    setNativeProps(nativeProps) {
       this._root.setNativeProps(nativeProps);
     }
 

--- a/Components/Row.js
+++ b/Components/Row.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React, {Component} from 'react';
-import {View, TouchableOpacity} from 'react-native';
+import {View, TouchableOpacity, StyleSheet} from 'react-native';
 
 import computeProps from '../Utils/computeProps';
 
@@ -9,9 +9,11 @@ import computeProps from '../Utils/computeProps';
 export default class RowNB extends Component {
     prepareRootProps() {
 
+        var flattenedStyle = StyleSheet.flatten(this.props.style)
+
         var type = {
         	flexDirection: 'row',
-        	flex: (this.props.size) ? this.props.size : (this.props.style && this.props.style.height) ? 0 : 1,
+        	flex: (this.props.size) ? this.props.size : (flattenedStyle && flattenedStyle.height) ? 0 : 1,
         }
 
         var defaultProps = {


### PR DESCRIPTION
Using `StyleSheet.flatten` before reading values of `this.props.style` in `Row` and `Col` to ensure all acceptable values of style work consistently.

Aiming to resolve https://github.com/GeekyAnts/react-native-easy-grid/issues/63