### PR TITLE
Adding onPress to the list of properties for Row and Col in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,16 @@
 declare module "react-native-easy-grid" {
 
     import {Component} from "react";
-    import {ViewProperties} from "react-native";
+    import {GestureResponderEvent, ViewProperties} from "react-native";
 
     export interface RowProps extends ViewProperties {
-        size?: number
+        size?: number,
+        onPress?: (event: GestureResponderEvent) => void
     }
 
     export interface ColProps extends ViewProperties {
-        size?: number
+        size?: number,
+        onPress?: (event: GestureResponderEvent) => void
     }
 
     export class Grid extends Component<ViewProperties, any> {}


### PR DESCRIPTION
`onPress` is a property accepted in [Row](https://github.com/GeekyAnts/react-native-easy-grid/blob/master/Components/Row.js#L29) (and similarly in Col). In both cases, the Views are wrapped with a TouchableOpacity that receive onPress as a property. 

This property, though, is not defined in index.d.ts, so typescript projects that use onPress on rows/cols will get an error. This PR adds this definition of onPress. 

The signature for onPress is the same one used for [TouchableOpacity](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/085e63ecf013cf29ea54ff603d99d31602127ef3/types/react-native/index.d.ts#L4721)'s onPress.